### PR TITLE
Expose Moriarty

### DIFF
--- a/holmes.cabal
+++ b/holmes.cabal
@@ -16,6 +16,7 @@ version:            0.1.0.0
 library
   exposed-modules: Control.Monad.Cell.Class
                  , Control.Monad.Holmes
+                 , Control.Monad.MoriarT
                  , Control.Monad.Watson
                  , Data.Input.Config
                  , Data.JoinSemilattice.Defined
@@ -23,8 +24,7 @@ library
                  , Data.Propagator
                  , Data.Holmes
 
-  other-modules: Control.Monad.MoriarT
-               , Data.JoinSemilattice.Class.Abs
+  other-modules: Data.JoinSemilattice.Class.Abs
                , Data.JoinSemilattice.Class.Boolean
                , Data.JoinSemilattice.Class.Eq
                , Data.JoinSemilattice.Class.FlatMapping


### PR DESCRIPTION
(best commit message ever)

The haddocks mention `MoriarT` and even link to it, but viewing the package on hackage, there are no docs for `MoriarT` and therefore links to it don't resolve.
This PR exposes `MoriarT` to fix that.