### PR TITLE
import Control.Monad.Fail to fix GHC 8.6 build

### DIFF
--- a/src/Control/Monad/Holmes.hs
+++ b/src/Control/Monad/Holmes.hs
@@ -36,6 +36,7 @@ module Control.Monad.Holmes
   , whenever
   ) where
 
+import Control.Monad.Fail (MonadFail (..))
 import Control.Monad.Cell.Class (MonadCell (..))
 import Control.Monad.IO.Class (MonadIO (..))
 import qualified Control.Monad.Cell.Class as Cell

--- a/src/Control/Monad/Watson.hs
+++ b/src/Control/Monad/Watson.hs
@@ -30,6 +30,7 @@ module Control.Monad.Watson
   , whenever
   ) where
 
+import Control.Monad.Fail (MonadFail (..))
 import Control.Monad.ST (ST, runST)
 import Control.Monad.Cell.Class (MonadCell (..))
 import qualified Control.Monad.Cell.Class as Cell


### PR DESCRIPTION
The package was failing to build on GHC 8.6:

```
/s/holmes/src/Control/Monad/Holmes.hs:62:10: error:
    Not in scope: type constructor or class ‘MonadFail’
   |        
62 | instance MonadFail Holmes where
   |          ^^^^^^^^^
```

Or see https://matrix.hackage.haskell.org/#/package/holmes.

I've checked that it builds with both GHC 8.6 and GHC 8.8 with this change; unfortunately it causes warnings on GHC 8.8 that I don't know how to avoid:

```
/s/holmes/src/Control/Monad/Watson.hs:33:1: warning: [-Wunused-imports]
    The import of ‘Control.Monad.Fail’ is redundant
      except perhaps to import instances from ‘Control.Monad.Fail’
    To import instances alone, use: import Control.Monad.Fail()
   |        
33 | import Control.Monad.Fail (MonadFail (..))
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```