### PR TITLE
Change version bounds to fix nixpkgs build

### DIFF
--- a/holmes.cabal
+++ b/holmes.cabal
@@ -38,7 +38,7 @@ library
                , Data.JoinSemilattice.Class.Zipping
                , Data.CDCL
 
-  build-depends: base >= 4.12 && < 4.14
+  build-depends: base >= 4.12 && < 4.15
                , containers >= 0.6 && < 0.7
                , hashable >= 1.3 && < 1.4
                , hedgehog >= 1.0 && < 1.1
@@ -65,7 +65,7 @@ test-suite examples
                , hspec >= 2.7 && < 2.8
                , split >= 0.2 && < 0.3
                , unordered-containers >= 0.2 && < 0.3
-               , relude >= 0.6 && < 0.7
+               , relude >= 0.6 && < 0.8
                , tasty >= 1.2 && < 1.3
                , tasty-discover
                , tasty-hspec


### PR DESCRIPTION
On the latest nixpkgs version, `holmes` fails to build, because it does not allow `relude-0.7.*.*` and `base-4.14.1.0`.

I bumped the bounds and checked locally that it builds + tests are green
