### PR TITLE
Update tasty version bound to allow 1.4.x

### DIFF
--- a/holmes.cabal
+++ b/holmes.cabal
@@ -66,7 +66,7 @@ test-suite examples
                , split >= 0.2 && < 0.3
                , unordered-containers >= 0.2 && < 0.3
                , relude >= 0.6 && < 0.8
-               , tasty >= 1.2 && < 1.3
+               , tasty >= 1.2 && < 1.5
                , tasty-discover
                , tasty-hspec
 
@@ -92,7 +92,7 @@ test-suite test
                , holmes
                , primitive >= 0.7 && < 0.8
                , transformers >= 0.5 && < 0.6
-               , tasty >= 1.2 && < 1.3
+               , tasty >= 1.2 && < 1.5
                , tasty-discover
                , tasty-hedgehog
                , tasty-hspec


### PR DESCRIPTION
Currently `holmes` is (again) marked as broken in nixpkgs.  Bumping the version bound of tasty to allow 1.4.2 (currently used in nixpkgs.haskellPackages) fixes it for me.

Could we add the `hacktoberfest-accepted` label to the PR? :)