### PR TITLE
Fix invalid input due to back-propagation, fixes #14

### DIFF
--- a/examples/Issue14.hs
+++ b/examples/Issue14.hs
@@ -1,0 +1,35 @@
+{-# Language BlockArguments #-}
+{-# Language FlexibleContexts #-}
+{-# Language PartialTypeSignatures #-}
+{-# Language TypeApplications #-}
+{-# Options_GHC -Wno-partial-type-signatures #-}
+module Issue14 where
+
+import Control.Monad.Watson (whenever, Watson)
+import Data.Holmes hiding (whenever)
+import Test.Hspec
+import Data.Word (Word8)
+import Data.Typeable (Typeable)
+
+issue14 ::
+  AbsR (jsl int) =>
+  Enum (Raw (jsl int)) =>
+  EqC jsl int =>
+  EqR jsl =>
+  Input (jsl int) =>
+  Num (Raw (jsl int)) =>
+  Num (jsl int) =>
+  SumR (jsl int) =>
+  Typeable int =>
+  [ [jsl int] ]
+issue14 = do
+  let guesses = 2 `from` [1 .. 3] :: Config (Watson _) _
+  guesses `whenever` \[a, b] ->
+    (a .+ b) .== 5
+
+spec_issue14 :: Spec
+spec_issue14 = do
+  it "handles constraints from the output when refining Defined inputs" do
+    issue14 @Defined @Int `shouldBe` [ [2,3], [3,2] ]
+  it "handles constraints from the output when refining Intersect inputs" do
+    issue14 @Intersect @Word8 `shouldBe` [ [2,3], [3,2] ]

--- a/holmes.cabal
+++ b/holmes.cabal
@@ -38,7 +38,7 @@ library
                , Data.JoinSemilattice.Class.Zipping
                , Data.CDCL
 
-  build-depends: base >= 4.12 && < 4.15
+  build-depends: base >= 4.12 && < 4.16
                , containers >= 0.6 && < 0.7
                , hashable >= 1.3 && < 1.4
                , hedgehog >= 1.0 && < 1.1
@@ -62,10 +62,10 @@ test-suite examples
   build-depends: base
                , hashable >= 1.3 && < 1.4
                , holmes
-               , hspec >= 2.7 && < 2.8
+               , hspec >= 2.7 && < 2.9
                , split >= 0.2 && < 0.3
                , unordered-containers >= 0.2 && < 0.3
-               , relude >= 0.6 && < 0.8
+               , relude >= 0.6 && < 1.1
                , tasty >= 1.2 && < 1.5
                , tasty-discover
                , tasty-hspec
@@ -125,7 +125,7 @@ test-suite readme
   build-depends: base
                , hashable >= 1.3 && < 1.4
                , holmes
-               , hspec >= 2.7 && < 2.8
+               , hspec >= 2.7 && < 2.9
   main-is:             README.lhs
   type:                exitcode-stdio-1.0
   default-language:    Haskell2010

--- a/holmes.cabal
+++ b/holmes.cabal
@@ -71,6 +71,7 @@ test-suite examples
                , tasty-hspec
 
   other-modules: Futoshiki
+               , Issue14
                , WaveFunctionCollapse
 
   ghc-options: -Wall -Wextra -threaded

--- a/src/Data/JoinSemilattice/Defined.hs
+++ b/src/Data/JoinSemilattice/Defined.hs
@@ -93,10 +93,12 @@ instance Fractional x => Fractional (Defined x) where
   fromRational = pure . fromRational
   recip        = fmap recip
 
-instance Input (Defined content) where
+instance Eq content => Input (Defined content) where
   type Raw (Defined content) = content
 
   from count options = Config (replicate count Unknown) do
     pure . \case
       Unknown -> map Exactly options
-      decided -> [ decided ]
+      Exactly a | a `elem` options -> [Exactly a]
+                | otherwise -> [Conflict]
+      Conflict -> [Conflict]


### PR DESCRIPTION
Setting the output to `trueR` in `MoriarT`'s `solve`
can back-propagate down to an input, setting it to `Exactly x`.
But then `refine`-ing that input must check that this `x`
does belong to the domain of that input,
otherwise that illegal input could lead to an illegal solution.